### PR TITLE
pass tests in scanner::forward and scanner::backward

### DIFF
--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -442,16 +442,20 @@ mod tests {
     use super::super::test_util::prepare_test_data_for_check_gc_fence;
     use super::super::ScannerBuilder;
     use super::*;
-    use crate::storage::kv::{Engine, TestEngineBuilder};
+    use crate::storage::kv::{Engine, Modify, TestEngineBuilder};
+    use crate::storage::mvcc::tests::write;
     use crate::storage::txn::tests::{
         must_commit, must_gc, must_prewrite_delete, must_prewrite_put, must_rollback,
     };
     use crate::storage::Scanner;
+    use kvproto::kvrpcpb::Context;
+    use engine_traits::{CF_LOCK, CF_WRITE};
 
     #[test]
     fn test_basic() {
         let engine = TestEngineBuilder::new().build().unwrap();
 
+        let ctx = Context::default();
         // Generate REVERSE_SEEK_BOUND / 2 Put for key [10].
         let k = &[10_u8];
         for ts in 0..REVERSE_SEEK_BOUND / 2 {
@@ -473,7 +477,16 @@ mod tests {
             if ts < REVERSE_SEEK_BOUND / 2 {
                 must_commit(&engine, k, ts, ts);
             } else {
-                must_rollback(&engine, k, ts);
+                let modifies = vec![
+                    // ts is rather small, so it is ok to `as u8`
+                    Modify::Put(
+                        CF_WRITE,
+                        Key::from_raw(k).append_ts(TimeStamp::new(ts)),
+                        vec![b'R', ts as u8],
+                    ),
+                    Modify::Delete(CF_LOCK, Key::from_raw(k)),
+                ];
+                write(&engine, &ctx, modifies);
             }
         }
 
@@ -491,7 +504,16 @@ mod tests {
         }
         for ts in REVERSE_SEEK_BOUND / 2 + 1..=REVERSE_SEEK_BOUND {
             must_prewrite_put(&engine, k, &[ts as u8], k, ts);
-            must_rollback(&engine, k, ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(k).append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(k)),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate 1 PUT for key [6].
@@ -505,7 +527,16 @@ mod tests {
         let k = &[5_u8];
         for ts in 0..=REVERSE_SEEK_BOUND {
             must_prewrite_put(&engine, k, &[ts as u8], k, ts);
-            must_rollback(&engine, k, ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(k).append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(k)),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate 1 PUT with ts = REVERSE_SEEK_BOUND and 1 PUT
@@ -699,10 +730,19 @@ mod tests {
     #[test]
     fn test_reverse_get_out_of_bound_1() {
         let engine = TestEngineBuilder::new().build().unwrap();
-
+        let ctx = Context::default();
         // Generate N/2 rollback for [b].
         for ts in 0..REVERSE_SEEK_BOUND / 2 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate 1 put for [c].
@@ -767,12 +807,21 @@ mod tests {
     #[test]
     fn test_reverse_get_out_of_bound_2() {
         let engine = TestEngineBuilder::new().build().unwrap();
-
+        let ctx = Context::default();
         // Generate 1 put and N/2 rollback for [b].
         must_prewrite_put(&engine, b"b", b"value_b", b"b", 0);
         must_commit(&engine, b"b", 0, 0);
         for ts in 1..=REVERSE_SEEK_BOUND / 2 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate 1 put for [c].

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -992,15 +992,18 @@ mod latest_kv_tests {
     use super::super::ScannerBuilder;
     use super::test_util::prepare_test_data_for_check_gc_fence;
     use super::*;
-    use crate::storage::kv::{Engine, TestEngineBuilder};
-    use crate::storage::Scanner;
-
+    use crate::storage::kv::{Engine, Modify, TestEngineBuilder};
+    use crate::storage::mvcc::tests::write;
     use crate::storage::txn::tests::*;
+    use crate::storage::Scanner;
+    use engine_traits::{CF_LOCK, CF_WRITE};
+    use kvproto::kvrpcpb::Context;
 
     /// Check whether everything works as usual when `ForwardKvScanner::get()` goes out of bound.
     #[test]
     fn test_get_out_of_bound() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"value", b"a", 7);
@@ -1008,7 +1011,16 @@ mod latest_kv_tests {
 
         // Generate 5 rollback for [b].
         for ts in 0..5 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
@@ -1053,14 +1065,23 @@ mod latest_kv_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_1() {
         let engine = TestEngineBuilder::new().build().unwrap();
-
+        let ctx = Context::default();
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
         // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
         for ts in 0..SEEK_BOUND / 2 {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND / 2);
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
@@ -1116,6 +1137,7 @@ mod latest_kv_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_2() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
@@ -1123,7 +1145,16 @@ mod latest_kv_tests {
 
         // Generate SEEK_BOUND-1 rollback and 1 put for [b] .
         for ts in 1..SEEK_BOUND {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND);
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
@@ -1303,18 +1334,20 @@ mod latest_kv_tests {
 mod latest_entry_tests {
     use super::super::ScannerBuilder;
     use super::*;
-    use crate::storage::txn::tests::{
-        must_commit, must_prewrite_delete, must_prewrite_put, must_rollback,
-    };
-    use crate::storage::{Engine, TestEngineBuilder};
+    use crate::storage::txn::tests::{must_commit, must_prewrite_delete, must_prewrite_put};
+    use crate::storage::{Modify,Engine, TestEngineBuilder};
 
     use super::test_util::*;
+    use crate::storage::mvcc::tests::write;
     use crate::storage::txn::EntryBatch;
+    use engine_traits::{CF_LOCK, CF_WRITE};
+    use kvproto::kvrpcpb::Context;
 
     /// Check whether everything works as usual when `EntryScanner::get()` goes out of bound.
     #[test]
     fn test_get_out_of_bound() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"value", b"a", 7);
@@ -1322,7 +1355,16 @@ mod latest_entry_tests {
 
         // Generate 5 rollback for [b].
         for ts in 0..5 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
@@ -1372,6 +1414,7 @@ mod latest_entry_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_1() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
@@ -1379,7 +1422,16 @@ mod latest_entry_tests {
 
         // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
         for ts in 0..SEEK_BOUND / 2 {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND / 2);
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
@@ -1441,6 +1493,7 @@ mod latest_entry_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_2() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
@@ -1448,7 +1501,16 @@ mod latest_entry_tests {
 
         // Generate SEEK_BOUND-1 rollback and 1 put for [b] .
         for ts in 1..SEEK_BOUND {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND);
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
@@ -1582,6 +1644,7 @@ mod latest_entry_tests {
     #[test]
     fn test_output_delete_and_after_ts() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate put for [a] at 3.
         must_prewrite_put(&engine, b"a", b"a_3", b"a", 3);
@@ -1597,7 +1660,16 @@ mod latest_entry_tests {
 
         // Generate rollbacks for [b] at 2, 3, 4.
         for ts in 2..5 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate delete for [b] at 10.
@@ -1685,16 +1757,19 @@ mod delta_entry_tests {
     use super::super::ScannerBuilder;
     use super::*;
     use crate::storage::txn::tests::*;
-    use crate::storage::{Engine, TestEngineBuilder};
+    use crate::storage::{Engine, Modify, TestEngineBuilder};
 
     use txn_types::{is_short_value, SHORT_VALUE_MAX_LEN};
 
     use super::test_util::*;
-
+    use crate::storage::mvcc::tests::write;
+    use engine_traits::{CF_LOCK, CF_WRITE};
+    use kvproto::kvrpcpb::Context;
     /// Check whether everything works as usual when `Delta::get()` goes out of bound.
     #[test]
     fn test_get_out_of_bound() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"value", b"a", 7);
@@ -1702,7 +1777,16 @@ mod delta_entry_tests {
 
         // Generate 5 rollback for [b].
         for ts in 0..5 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
@@ -1752,14 +1836,23 @@ mod delta_entry_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_1() {
         let engine = TestEngineBuilder::new().build().unwrap();
-
+        let ctx = Context::default();
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
         // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
         for ts in 0..SEEK_BOUND / 2 {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND / 2);
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
@@ -1821,6 +1914,7 @@ mod delta_entry_tests {
     #[test]
     fn test_move_next_user_key_out_of_bound_2() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate 1 put for [a].
         must_prewrite_put(&engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
@@ -1830,7 +1924,16 @@ mod delta_entry_tests {
         // It differs from EntryScanner that this will try to fetch multiple versions of each key.
         // So in this test it needs one more next than EntryScanner.
         for ts in 1..=SEEK_BOUND {
-            must_rollback(&engine, b"b", ts as u64);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND + 1);
         must_commit(&engine, b"b", SEEK_BOUND + 1, SEEK_BOUND + 1);
@@ -2210,6 +2313,7 @@ mod delta_entry_tests {
     #[test]
     fn test_output_old_value() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
 
         // Generate put for [a] at 1.
         must_prewrite_put(&engine, b"a", b"a_1", b"a", 1);
@@ -2228,7 +2332,16 @@ mod delta_entry_tests {
 
         // Generate rollbacks for [b] at 6, 7, 8.
         for ts in 6..9 {
-            must_rollback(&engine, b"b", ts);
+            let modifies = vec![
+                // ts is rather small, so it is ok to `as u8`
+                Modify::Put(
+                    CF_WRITE,
+                    Key::from_raw(b"b").append_ts(TimeStamp::new(ts)),
+                    vec![b'R', ts as u8],
+                ),
+                Modify::Delete(CF_LOCK, Key::from_raw(b"b")),
+            ];
+            write(&engine, &ctx, modifies);
         }
 
         // Generate delete for [b] at 10.


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

###  What have you changed?

Make the tests in `scanner` pass by writing raw modifies into `Engine`.

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->
###  Refer to a related PR or issue link (optional)

tikv/tikv#9514

